### PR TITLE
32 add neutron target to tcsgen

### DIFF
--- a/GenOptions.dat
+++ b/GenOptions.dat
@@ -9,4 +9,5 @@ LUND     0
 Seed     0
 vzMax    2.5
 vzMin    -2.5
-Fermi    0
+Fermi    1
+targetPID 2112

--- a/GenOptions.dat
+++ b/GenOptions.dat
@@ -7,3 +7,6 @@ MinvMin  1.2
 Q2Cut    0.02
 LUND     0
 Seed     0
+vzMax    2.5
+vzMin    -2.5
+Fermi    0

--- a/GenOptions.dat
+++ b/GenOptions.dat
@@ -5,9 +5,10 @@ EgMin    4
 EgMax    10.6
 vzMax    2.5
 vzMin    -2.5
-MinvMin  1.2
+MinvMin  2.0
 Q2Cut    0.02
 LUND     0
 Seed     0
-Fermi    0
+Fermi    1
 targetPID    2212
+X0      769.1

--- a/GenOptions.dat
+++ b/GenOptions.dat
@@ -9,5 +9,5 @@ MinvMin  1.2
 Q2Cut    0.02
 LUND     0
 Seed     0
-Fermi    1
-targetPID    2112
+Fermi    0
+targetPID    2212

--- a/GenOptions.dat
+++ b/GenOptions.dat
@@ -3,11 +3,11 @@ Eb       10.6
 tLim     -1.8
 EgMin    4
 EgMax    10.6
+vzMax    2.5
+vzMin    -2.5
 MinvMin  1.2
 Q2Cut    0.02
 LUND     0
 Seed     0
-vzMax    2.5
-vzMin    -2.5
 Fermi    1
-targetPID 2112
+targetPID    2112

--- a/README.md
+++ b/README.md
@@ -33,4 +33,5 @@ cross section calculation, it uses that grid.
 - tLim          The t_Max value in GeV
 - EgMin         Photon energy minimum
 - EgMax         Photon energy maximum
-- Fermi         Add Fermi momentum to target nucleon
+- Fermi         Add Fermi momentum to target nucleon (defaults to 0)
+- targetPID     Target PID (currently accepts 2112 and 2212, defaults to 2212)

--- a/README.md
+++ b/README.md
@@ -33,3 +33,4 @@ cross section calculation, it uses that grid.
 - tLim          The t_Max value in GeV
 - EgMin         Photon energy minimum
 - EgMax         Photon energy maximum
+- Fermi         Add Fermi momentum to target nucleon

--- a/TCSGen
+++ b/TCSGen
@@ -26,6 +26,7 @@ def main():
     MinvMin = 2;
     vz_max =  2.5;
     vz_min = -2.5;
+    Fermi  = 0;
 
     try:
         opts, args = getopt.getopt(sys.argv[1:], "n:e:t:lhor", ["help", "output=", "Egmin=", "Egmax=", "MinvMin=", "q2Cut=", "LUND", "Run", "trig=", "seed=", "docker", "vzMin=", "vzMax="])
@@ -62,6 +63,8 @@ def main():
             vz_max = a;
         elif o in ("-l", "--LUND"):
             LUND = 1
+        elif o == "--Fermi":
+            Fermi = a
         elif o in ("-r", "--Run"):
             Run = True;
         elif o in("--docker"):
@@ -85,7 +88,8 @@ def main():
     optFile.write("MinvMin  " + str(MinvMin) + "\n");
     optFile.write("Q2Cut    " + str(Q2Cut) + "\n");
     optFile.write("LUND     " + str(LUND)  + "\n");
-    optFile.write("Seed     " + str(Seed));
+    optFile.write("Seed     " + str(Seed) + "\n");
+    optFile.write("Fermi    " + str(Fermi));
 
     optFile.close()
 

--- a/TCSGen
+++ b/TCSGen
@@ -27,6 +27,7 @@ def main():
     vz_max =  2.5;
     vz_min = -2.5;
     Fermi  = 0;
+    targetPID = 2212;
 
     try:
         opts, args = getopt.getopt(sys.argv[1:], "n:e:t:lhor", ["help", "output=", "Egmin=", "Egmax=", "MinvMin=", "q2Cut=", "LUND", "Run", "trig=", "seed=", "docker", "vzMin=", "vzMax="])
@@ -65,6 +66,8 @@ def main():
             LUND = 1
         elif o == "--Fermi":
             Fermi = a
+        elif o == "--targetPID":
+            targetPID = a
         elif o in ("-r", "--Run"):
             Run = True;
         elif o in("--docker"):
@@ -89,7 +92,8 @@ def main():
     optFile.write("Q2Cut    " + str(Q2Cut) + "\n");
     optFile.write("LUND     " + str(LUND)  + "\n");
     optFile.write("Seed     " + str(Seed) + "\n");
-    optFile.write("Fermi    " + str(Fermi));
+    optFile.write("Fermi    " + str(Fermi) + "\n");
+    optFile.write("targetPID    " + str(targetPID));
 
     optFile.close()
 

--- a/TCSGen.cc
+++ b/TCSGen.cc
@@ -335,6 +335,7 @@ int main(int argc, char** argv) {
                     << pz_nuc << setw(15) << L_nuc.E() << setw(5) << M_nuc << setw(5) << 0 << setw(5) << 0 << setw(15) << vz << endl;
 
         } else {
+            i = i - 1;
             cout << " |t_min| > |t_lim|" << endl;
             cout << " t_min =  " << t_min << "   t_lim = " << t_lim << "  Eg = " << Eg << endl;
         }

--- a/TCSGen.cc
+++ b/TCSGen.cc
@@ -63,6 +63,7 @@ int main(int argc, char** argv) {
     int seed;
     double vz_max;
     double vz_min;
+    bool isFermi;
     
     for( map<std::string, std::string>::iterator it =  m_Settings.begin(); it!= m_Settings.end(); it++ ){
     
@@ -91,6 +92,8 @@ int main(int argc, char** argv) {
             vz_max = atof(val.c_str());
         }else if( key.compare("vzMin") == 0 ){
             vz_min = atof(val.c_str());
+        }else if (key.compare("Fermi") == 0) {
+            isFermi = atof(val.c_str());
         }
         
     }
@@ -105,6 +108,7 @@ int main(int argc, char** argv) {
     cout << "vz_max = " << vz_max << endl;
     cout << "vz_min = " << vz_min << endl;
     cout<<"IsLund = "<<isLund<<endl;
+    cout<<"IsFermi = "<<isFermi<<endl;
     
     cout<<"**************************************************"<<endl;
     cout<<"*******"<<" RandomSeedActuallyUsed: "<<seed<<" *******"<<endl;
@@ -143,11 +147,15 @@ int main(int argc, char** argv) {
     TH2D *h_ph_h_ph_cm1 = new TH2D("h_ph_h_ph_cm1", "", 200, 0., 360., 200, 0., 360.);
     TH2D *h_th_g_th_cm1 = new TH2D("h_th_g_th_cm1", "", 200, 0., 180., 200, 0., 180.);
 
+    TF1 *f_FermiDistr = new TF1("f_FermiDistr", Fermi_Distribution, 0., 1, 0);
+    TH1D *h_P_Fermi1 = new TH1D("h_P_Fermi1", "", 200, 0., 1.05);
+
     //================= Definition of Tree Variables =================
     double Eg, Minv, t, Q2,s,eta;
     double psf, crs_BH, crs_INT, crs_int;
     double psf_flux, flux_factor;
     TLorentzVector L_em, L_ep, L_prot;
+    TLorentzVector L_ProtFermi;
     TLorentzVector L_gprime;
 
     TTree *tr1 = new TTree("tr1", "TCS MC events");
@@ -169,10 +177,26 @@ int main(int argc, char** argv) {
             cout.flush() << "Processed " << i << " events, approximetely " << double(100. * i / double(Nsim)) << "%\r";
         }
 
+        // Check if Fermi option is active, if so generrate Fermi momentum for proton,
+        // Otherwise the proton is at rest
+        // Let's take it in the range of 0 to 1 GeV
+        double p_prot_Fermi = isFermi ? f_FermiDistr->GetRandom(0., 1.) : 0;
+
+        h_P_Fermi1->Fill(p_prot_Fermi);
+
+        double cosThFermi = rand.Uniform(-1., 1);
+        double sinThFermi = sqrt(1. - cosThFermi * cosThFermi);
+        double phiFermi = rand.Uniform(0, 2 * PI);
+
+        double pxFermi = p_prot_Fermi * sinThFermi * cos(phiFermi);
+        double pyFermi = p_prot_Fermi * sinThFermi * sin(phiFermi);
+        double pzFermi = p_prot_Fermi*cosThFermi;
+        double EFermi = sqrt(p_prot_Fermi * p_prot_Fermi + Mp * Mp);
+
         double psf_Eg = Eg_max - Eg_min;
         Eg = rand.Uniform(Eg_min, Eg_min + psf_Eg);
         flux_factor = N_EPA(Eb, Eg, q2_cut) + N_Brem(Eg, Eb);
-        s = Mp * Mp + 2 * Mp*Eg;
+        s = Mp * Mp + 2 * Eg*(EFermi - p_prot_Fermi*cosThFermi );;
         double t_min = T_min(0., Mp*Mp, MinvMin2, Mp*Mp, s);
         double t_max = T_max(0., Mp*Mp, MinvMin2, Mp*Mp, s);
         double psf_t = t_min - TMath::Max(t_max, t_lim);
@@ -191,7 +215,8 @@ int main(int argc, char** argv) {
 
             double Pprime = 0.5 * sqrt(Lambda(s, Q2, Mp * Mp) / s); // Momentum in c.m. it is the same for q_pr and p_pr
 
-            Lcm.SetPxPyPzE(0., 0., Eg, Mp + Eg);
+            // ** The LorentzVector of CM frame is equal L_gamma + L_proton_Fermi
+            Lcm.SetPxPyPzE(pxFermi, pyFermi, pzFermi + Eg, EFermi + Eg);
             L_prot.SetPxPyPzE(Pprime * sin(th_pprime), 0., Pprime * cos(th_pprime), sqrt(Pprime * Pprime + Mp * Mp));
             L_gprime.SetPxPyPzE(Pprime * sin(th_qprime), 0., Pprime * cos(th_qprime), sqrt(Pprime * Pprime + Q2));
 
@@ -286,7 +311,7 @@ int main(int argc, char** argv) {
     tr1->Write();
     h_ph_h_ph_cm1->Write();
     h_th_g_th_cm1->Write();
-
+    h_P_Fermi1->Write();
 
     file_out->Close();
 

--- a/TCSGen.cc
+++ b/TCSGen.cc
@@ -282,6 +282,7 @@ int main(int argc, char** argv) {
             crs_BH = crs_lmlp.Eval_BH(s, Q2, t, -1, tcs_kin1.GetPhi_cm(), tcs_kin1.GetTheta_cm()); // -1: cros section is not weighted by L/L0
 
             if(std::isnan(crs_BH)){
+              i = i - 1;
               //happens because denominator is greater than nomitor in acos term th_qprime
               //guessing adding fermi momentum leads to Q2Max being incorrect?
               cout<<"BH crs is nan. Will skip this event"<<endl;

--- a/TCSGen.cc
+++ b/TCSGen.cc
@@ -65,6 +65,8 @@ int main(int argc, char** argv) {
     double vz_min;
     bool isFermi=0; //default
     int targetPID=2212; //default
+    double X0=929.;//default (LH2)
+    double dt=5.0;//default (RG-A, RG-B targets)
     
     for( map<std::string, std::string>::iterator it =  m_Settings.begin(); it!= m_Settings.end(); it++ ){
     
@@ -97,6 +99,10 @@ int main(int argc, char** argv) {
             isFermi = atof(val.c_str());
         }else if (key.compare("targetPID") == 0) {
             targetPID = atof(val.c_str());
+        }else if (key.compare("X0") == 0) {
+            X0 = atof(val.c_str());
+        }else if (key.compare("target_length") == 0) {
+            dt = atof(val.c_str());
         }
         
     }
@@ -147,6 +153,7 @@ int main(int argc, char** argv) {
     crs_lmlp.Set_targetPID(targetPID);
 
     TLorentzVector target(0., 0., 0., M_nuc);
+    TLorentzVector beam(0.,0.0,Eb,sqrt(0.00051*0.00051+Eb*Eb));
     TLorentzVector Lcm;
 
     TFile *file_out = new TFile("tcs_gen.root", "Recreate");
@@ -158,8 +165,10 @@ int main(int argc, char** argv) {
     TF1 *f_FermiDistr = new TF1("f_FermiDistr", Fermi_Distribution, 0., 1, 0);
     TH1D *h_P_Fermi1 = new TH1D("h_P_Fermi1", "", 200, 0., 1.05);
 
+    TH1D *h_MM2 = new TH1D("h_MM2", "MM^{2}", 100, -0.5, 0.5);
+
     //================= Definition of Tree Variables =================
-    double Eg, Minv, t, Q2,s,eta;
+    double Eg, Minv, t, Q2,s,eta,MM2;
     double psf, crs_BH, crs_INT, crs_int;
     double psf_flux, flux_factor;
     TLorentzVector L_em, L_ep, L_nuc;
@@ -172,6 +181,7 @@ int main(int argc, char** argv) {
     tr1->Branch("L_nuc", "TLorentzVector", &L_nuc, 3200, 99);
     tr1->Branch("Eg", &Eg, "Eg/D");
     tr1->Branch("Q2", &Q2, "Q2/D");
+    tr1->Branch("MM2", &MM2, "Q2/D");
     tr1->Branch("t", &t, "t/D");
     tr1->Branch("s", &s, "s/D");
     tr1->Branch("eta", &eta, "eta/D");    
@@ -203,7 +213,7 @@ int main(int argc, char** argv) {
 
         double psf_Eg = Eg_max - Eg_min;
         Eg = rand.Uniform(Eg_min, Eg_min + psf_Eg);
-        flux_factor = N_EPA(Eb, Eg, q2_cut, targetPID) + N_Brem(Eg, Eb);
+        flux_factor = N_EPA(Eb, Eg, q2_cut, targetPID) + N_Brem(Eg, Eb,dt,X0);
         s = M_nuc * M_nuc + 2 * Eg*(EFermi - p_nuc_Fermi*cosThFermi );
         double t_min = T_min(0., M_nuc*M_nuc, MinvMin2, M_nuc*M_nuc, s);
         double t_max = T_max(0., M_nuc*M_nuc, MinvMin2, M_nuc*M_nuc, s);
@@ -287,6 +297,11 @@ int main(int argc, char** argv) {
                 crs_INT = 0;
             }
 
+            TLorentzVector miss = beam + target - L_em - L_ep - L_nuc;
+
+            MM2 = miss.M2();
+            h_MM2->Fill(MM2);
+            
             tr1->Fill();
 
             //======================== Write LUND file ================================
@@ -302,20 +317,21 @@ int main(int argc, char** argv) {
             double vz = rand.Uniform(vz_min, vz_max);
             //double vz = 0.;
 
+
             //============= Write Header ===================
             out_dat << 3 << setw(5) << 1 << setw(5) << 1 << setw(5) << 0 << " " << setw(5) << "  " << psf << " " << setw(15) << 0 << setw(15)
                     << flux_factor << setw(15) << 0 << setw(5) << 0 << setw(5) << " " << crs_BH << endl;
             // =============== WWrite Particles ============
             //====== e- ======
             out_dat << 1 << setw(5) << -1 << setw(5) << 1 << setw(7) << 11 << setw(5) << 0 << setw(5) << 0 << setw(15) << px_em << setw(15) << py_em << setw(15)
-                    << pz_em << setw(15) << L_em.E() << setw(5) << 0 << setw(5) << 0 << setw(5) << 0 << setw(15) << vz << endl;
+                    << pz_em << setw(15) << L_em.E() << setw(5) << Me << setw(5) << 0 << setw(5) << 0 << setw(15) << vz << endl;
             //====== e+ ======
             out_dat << 2 << setw(5) << +1 << setw(5) << 1 << setw(7) << -11 << setw(5) << 0 << setw(5) << 0 << setw(15) << px_ep << setw(15) << py_ep << setw(15)
-                    << pz_ep << setw(15) << L_ep.E() << setw(5) << 0 << setw(5) << 0 << setw(5) << 0 << setw(15) << vz << endl;
+                    << pz_ep << setw(15) << L_ep.E() << setw(5) << Me << setw(5) << 0 << setw(5) << 0 << setw(15) << vz << endl;
 
-            //====== nucon ======
+            //====== nuc ======
             out_dat << 3 << setw(5) << +1 << setw(5) << 1 << setw(7) << targetPID << setw(5) << 0 << setw(5) << 0 << setw(15) << px_nuc << setw(15) << py_nuc << setw(15)
-                    << pz_nuc << setw(15) << L_nuc.E() << setw(5) << 0 << setw(5) << 0 << setw(5) << 0 << setw(15) << vz << endl;
+                    << pz_nuc << setw(15) << L_nuc.E() << setw(5) << M_nuc << setw(5) << 0 << setw(5) << 0 << setw(15) << vz << endl;
 
         } else {
             cout << " |t_min| > |t_lim|" << endl;
@@ -327,6 +343,7 @@ int main(int argc, char** argv) {
     h_ph_h_ph_cm1->Write();
     h_th_g_th_cm1->Write();
     h_P_Fermi1->Write();
+    h_MM2->Write();
 
     file_out->Close();
 

--- a/TCSGen.cc
+++ b/TCSGen.cc
@@ -204,7 +204,7 @@ int main(int argc, char** argv) {
         double psf_Eg = Eg_max - Eg_min;
         Eg = rand.Uniform(Eg_min, Eg_min + psf_Eg);
         flux_factor = N_EPA(Eb, Eg, q2_cut, targetPID) + N_Brem(Eg, Eb);
-        s = M_nuc * M_nuc + 2 * Eg*(EFermi - p_nuc_Fermi*cosThFermi );;
+        s = M_nuc * M_nuc + 2 * Eg*(EFermi - p_nuc_Fermi*cosThFermi );
         double t_min = T_min(0., M_nuc*M_nuc, MinvMin2, M_nuc*M_nuc, s);
         double t_max = T_max(0., M_nuc*M_nuc, MinvMin2, M_nuc*M_nuc, s);
         double psf_t = t_min - TMath::Max(t_max, t_lim);
@@ -270,6 +270,13 @@ int main(int argc, char** argv) {
 
             //crs_lmlp.Set_SQ2t(s, Q2, t);
             crs_BH = crs_lmlp.Eval_BH(s, Q2, t, -1, tcs_kin1.GetPhi_cm(), tcs_kin1.GetTheta_cm()); // -1: cros section is not weighted by L/L0
+
+            if(std::isnan(crs_BH)){
+              //happens because denominator is greater than nomitor in acos term th_qprime
+              //guessing adding fermi momentum leads to Q2Max being incorrect?
+              cout<<"BH crs is nan. Will skip this event"<<endl;
+              continue;
+            }
 
             eta = Q2 / (2 * (s - M_nuc * M_nuc) - Q2);
 

--- a/TCSGen.cc
+++ b/TCSGen.cc
@@ -122,17 +122,17 @@ int main(int argc, char** argv) {
     const double radian = 57.2957795130823229;
     const double M_p = 0.9383;
     const double M_n = 0.939565;
-    double Mp=M_p;
-    if(targetPID==2112){Mp=M_n;}
+    double M_nuc=M_p;
+    if(targetPID==2112){M_nuc=M_n;}
     const double Me = 0.00051;
-    //  const double Minv_min = sqrt(Mp*Mp + 2*Mp*Eg_min ) - Mp;
+    //  const double Minv_min = sqrt(M_nuc*M_nuc + 2*M_nuc*Eg_min ) - M_nuc;
     
-    const double Minv_Egmin = sqrt( Mp*Mp + 2*Mp*Eg_min ) - Mp; // This is the maximum mass square that is accessible with a given Egmin, 
+    const double Minv_Egmin = sqrt( M_nuc*M_nuc + 2*M_nuc*Eg_min ) - M_nuc; // This is the maximum mass square that is accessible with a given Egmin, 
                                                                  // if the User specified MinvMin is above this value, then EgMin needs to be overwritten to a Eg, that will allow MinvMin production.
     
     if( Minv_Egmin < MinvMin ){
         double EgMinOld = Eg_min;
-        Eg_min = (MinvMin*MinvMin + 2*Mp*MinvMin)/(2*Mp);
+        Eg_min = (MinvMin*MinvMin + 2*M_nuc*MinvMin)/(2*M_nuc);
         cout<<"With the given Eg_min, the mass "<<MinvMin<<" GeV is not reachable, so the Eg min will be adjusted from "<<EgMinOld<<" GeV to "<<Eg_min<<" GeV"<<endl;
     }
     
@@ -142,11 +142,11 @@ int main(int argc, char** argv) {
     TRandom2 rand;
     rand.SetSeed(seed);
 
-    TTCSKine tcs_kin1(Mp, Eb);
+    TTCSKine tcs_kin1(M_nuc, Eb);
     TTCSCrs crs_lmlp;
     crs_lmlp.Set_targetPID(targetPID);
 
-    TLorentzVector target(0., 0., 0., Mp);
+    TLorentzVector target(0., 0., 0., M_nuc);
     TLorentzVector Lcm;
 
     TFile *file_out = new TFile("tcs_gen.root", "Recreate");
@@ -162,14 +162,14 @@ int main(int argc, char** argv) {
     double Eg, Minv, t, Q2,s,eta;
     double psf, crs_BH, crs_INT, crs_int;
     double psf_flux, flux_factor;
-    TLorentzVector L_em, L_ep, L_prot;
-    TLorentzVector L_ProtFermi;
+    TLorentzVector L_em, L_ep, L_nuc;
+    TLorentzVector L_nucFermi;
     TLorentzVector L_gprime;
 
     TTree *tr1 = new TTree("tr1", "TCS MC events");
     tr1->Branch("L_em", "TLorentzVector", &L_em, 3200, 99);
     tr1->Branch("L_ep", "TLorentzVector", &L_ep, 3200, 99);
-    tr1->Branch("L_prot", "TLorentzVector", &L_prot, 3200, 99);
+    tr1->Branch("L_nuc", "TLorentzVector", &L_nuc, 3200, 99);
     tr1->Branch("Eg", &Eg, "Eg/D");
     tr1->Branch("Q2", &Q2, "Q2/D");
     tr1->Branch("t", &t, "t/D");
@@ -185,47 +185,47 @@ int main(int argc, char** argv) {
             cout.flush() << "Processed " << i << " events, approximetely " << double(100. * i / double(Nsim)) << "%\r";
         }
 
-        // Check if Fermi option is active, if so generrate Fermi momentum for proton,
-        // Otherwise the proton is at rest
+        // Check if Fermi option is active, if so generrate Fermi momentum for nucon,
+        // Otherwise the nucon is at rest
         // Let's take it in the range of 0 to 1 GeV
-        double p_prot_Fermi = isFermi ? f_FermiDistr->GetRandom(0., 1.) : 0;
+        double p_nuc_Fermi = isFermi ? f_FermiDistr->GetRandom(0., 1.) : 0;
 
-        h_P_Fermi1->Fill(p_prot_Fermi);
+        h_P_Fermi1->Fill(p_nuc_Fermi);
 
         double cosThFermi = rand.Uniform(-1., 1);
         double sinThFermi = sqrt(1. - cosThFermi * cosThFermi);
         double phiFermi = rand.Uniform(0, 2 * PI);
 
-        double pxFermi = p_prot_Fermi * sinThFermi * cos(phiFermi);
-        double pyFermi = p_prot_Fermi * sinThFermi * sin(phiFermi);
-        double pzFermi = p_prot_Fermi*cosThFermi;
-        double EFermi = sqrt(p_prot_Fermi * p_prot_Fermi + Mp * Mp);
+        double pxFermi = p_nuc_Fermi * sinThFermi * cos(phiFermi);
+        double pyFermi = p_nuc_Fermi * sinThFermi * sin(phiFermi);
+        double pzFermi = p_nuc_Fermi*cosThFermi;
+        double EFermi = sqrt(p_nuc_Fermi * p_nuc_Fermi + M_nuc * M_nuc);
 
         double psf_Eg = Eg_max - Eg_min;
         Eg = rand.Uniform(Eg_min, Eg_min + psf_Eg);
         flux_factor = N_EPA(Eb, Eg, q2_cut, targetPID) + N_Brem(Eg, Eb);
-        s = Mp * Mp + 2 * Eg*(EFermi - p_prot_Fermi*cosThFermi );;
-        double t_min = T_min(0., Mp*Mp, MinvMin2, Mp*Mp, s);
-        double t_max = T_max(0., Mp*Mp, MinvMin2, Mp*Mp, s);
+        s = M_nuc * M_nuc + 2 * Eg*(EFermi - p_nuc_Fermi*cosThFermi );;
+        double t_min = T_min(0., M_nuc*M_nuc, MinvMin2, M_nuc*M_nuc, s);
+        double t_max = T_max(0., M_nuc*M_nuc, MinvMin2, M_nuc*M_nuc, s);
         double psf_t = t_min - TMath::Max(t_max, t_lim);
 
         if (t_min > t_lim) {
             t = rand.Uniform(t_min - psf_t, t_min);
-            double Q2max = 2 * Mp * Eg + t - (Eg / Mp)*(2 * Mp * Mp - t - sqrt(t * t - 4 * Mp * Mp * t)); // Page 182 of my notebook. Derived using "Q2max = s + t - 2Mp**2 + u_max" relation
+            double Q2max = 2 * M_nuc * Eg + t - (Eg / M_nuc)*(2 * M_nuc * M_nuc - t - sqrt(t * t - 4 * M_nuc * M_nuc * t)); // Page 182 of my notebook. Derived using "Q2max = s + t - 2Mp**2 + u_max" relation
 
             double psf_Q2 = Q2max - MinvMin2;
 
             Q2 = rand.Uniform(MinvMin2, MinvMin2 + psf_Q2);
 
-            double u = 2 * Mp * Mp + Q2 - s - t;
-            double th_qprime = acos((s * (t - u) - Mp * Mp * (Q2 - Mp * Mp)) / sqrt(Lambda(s, 0, Mp * Mp) * Lambda(s, Q2, Mp * Mp))); //Byukling Kayanti (4.9)
+            double u = 2 * M_nuc * M_nuc + Q2 - s - t;
+            double th_qprime = acos((s * (t - u) - M_nuc * M_nuc * (Q2 - M_nuc * M_nuc)) / sqrt(Lambda(s, 0, M_nuc * M_nuc) * Lambda(s, Q2, M_nuc * M_nuc))); //Byukling Kayanti (4.9)
             double th_pprime = PI + th_qprime;
 
-            double Pprime = 0.5 * sqrt(Lambda(s, Q2, Mp * Mp) / s); // Momentum in c.m. it is the same for q_pr and p_pr
+            double Pprime = 0.5 * sqrt(Lambda(s, Q2, M_nuc * M_nuc) / s); // Momentum in c.m. it is the same for q_pr and p_pr
 
-            // ** The LorentzVector of CM frame is equal L_gamma + L_proton_Fermi
+            // ** The LorentzVector of CM frame is equal L_gamma + L_nucon_Fermi
             Lcm.SetPxPyPzE(pxFermi, pyFermi, pzFermi + Eg, EFermi + Eg);
-            L_prot.SetPxPyPzE(Pprime * sin(th_pprime), 0., Pprime * cos(th_pprime), sqrt(Pprime * Pprime + Mp * Mp));
+            L_nuc.SetPxPyPzE(Pprime * sin(th_pprime), 0., Pprime * cos(th_pprime), sqrt(Pprime * Pprime + M_nuc * M_nuc));
             L_gprime.SetPxPyPzE(Pprime * sin(th_qprime), 0., Pprime * cos(th_qprime), sqrt(Pprime * Pprime + Q2));
 
             double psf_cos_th = 2.; // cos(th):(-1 : 1)
@@ -252,16 +252,16 @@ int main(int argc, char** argv) {
 
 
             L_gprime.Boost(Lcm.BoostVector());
-            L_prot.Boost(Lcm.BoostVector());
+            L_nuc.Boost(Lcm.BoostVector());
 
             double psf_phi_lab = 2 * PI;
             double phi_rot = rand.Uniform(0., psf_phi_lab);
 
-            L_prot.RotateZ(phi_rot);
+            L_nuc.RotateZ(phi_rot);
             L_gprime.RotateZ(phi_rot);
             L_em.RotateZ(phi_rot);
             L_ep.RotateZ(phi_rot);
-            tcs_kin1.SetLemLepLp(L_em, L_ep, L_prot);
+            tcs_kin1.SetLemLepLp(L_em, L_ep, L_nuc);
 
             h_ph_h_ph_cm1->Fill(phi_cm * TMath::RadToDeg(), tcs_kin1.GetPhi_cm());
             h_th_g_th_cm1->Fill(acos(cos_th) * TMath::RadToDeg(), tcs_kin1.GetTheta_cm());
@@ -271,11 +271,11 @@ int main(int argc, char** argv) {
             //crs_lmlp.Set_SQ2t(s, Q2, t);
             crs_BH = crs_lmlp.Eval_BH(s, Q2, t, -1, tcs_kin1.GetPhi_cm(), tcs_kin1.GetTheta_cm()); // -1: cros section is not weighted by L/L0
 
-            eta = Q2 / (2 * (s - Mp * Mp) - Q2);
+            eta = Q2 / (2 * (s - M_nuc * M_nuc) - Q2);
 
             if (Q2 < 9. && -t < 0.8 && eta < 0.8) {
                 crs_INT = crs_lmlp.Eval_INT(s, Q2, t, -1., tcs_kin1.GetPhi_cm(), tcs_kin1.GetTheta_cm(), 2.); //the last argument "1" is the sc_D
-                //crs_INT = crs_lmlp.Eval_INT( tcs_kin1.GetPhi_cm(), tcs_kin1.GetTheta_cm(), 1.,targetPID); //the last argument "1" is the sc_D
+                //crs_INT = crs_lmlp.Eval_INT( tcs_kin1.GetPhi_cm(), tcs_kin1.GetTheta_cm(), 1.); //the last argument "1" is the sc_D
             } else {
                 crs_INT = 0;
             }
@@ -289,9 +289,9 @@ int main(int argc, char** argv) {
             double px_ep = L_ep.Px();
             double py_ep = L_ep.Py();
             double pz_ep = L_ep.Pz();
-            double px_prot = L_prot.Px();
-            double py_prot = L_prot.Py();
-            double pz_prot = L_prot.Pz();
+            double px_nuc = L_nuc.Px();
+            double py_nuc = L_nuc.Py();
+            double pz_nuc = L_nuc.Pz();
             double vz = rand.Uniform(vz_min, vz_max);
             //double vz = 0.;
 
@@ -306,9 +306,9 @@ int main(int argc, char** argv) {
             out_dat << 2 << setw(5) << +1 << setw(5) << 1 << setw(7) << -11 << setw(5) << 0 << setw(5) << 0 << setw(15) << px_ep << setw(15) << py_ep << setw(15)
                     << pz_ep << setw(15) << L_ep.E() << setw(5) << 0 << setw(5) << 0 << setw(5) << 0 << setw(15) << vz << endl;
 
-            //====== proton ======
-            out_dat << 3 << setw(5) << +1 << setw(5) << 1 << setw(7) << targetPID << setw(5) << 0 << setw(5) << 0 << setw(15) << px_prot << setw(15) << py_prot << setw(15)
-                    << pz_prot << setw(15) << L_prot.E() << setw(5) << 0 << setw(5) << 0 << setw(5) << 0 << setw(15) << vz << endl;
+            //====== nucon ======
+            out_dat << 3 << setw(5) << +1 << setw(5) << 1 << setw(7) << targetPID << setw(5) << 0 << setw(5) << 0 << setw(15) << px_nuc << setw(15) << py_nuc << setw(15)
+                    << pz_nuc << setw(15) << L_nuc.E() << setw(5) << 0 << setw(5) << 0 << setw(5) << 0 << setw(15) << vz << endl;
 
         } else {
             cout << " |t_min| > |t_lim|" << endl;

--- a/TCSGen.cc
+++ b/TCSGen.cc
@@ -63,7 +63,8 @@ int main(int argc, char** argv) {
     int seed;
     double vz_max;
     double vz_min;
-    bool isFermi;
+    bool isFermi=0; //default
+    int targetPID=2212; //default
     
     for( map<std::string, std::string>::iterator it =  m_Settings.begin(); it!= m_Settings.end(); it++ ){
     
@@ -94,6 +95,8 @@ int main(int argc, char** argv) {
             vz_min = atof(val.c_str());
         }else if (key.compare("Fermi") == 0) {
             isFermi = atof(val.c_str());
+        }else if (key.compare("targetPID") == 0) {
+            targetPID = atof(val.c_str());
         }
         
     }
@@ -109,6 +112,7 @@ int main(int argc, char** argv) {
     cout << "vz_min = " << vz_min << endl;
     cout<<"IsLund = "<<isLund<<endl;
     cout<<"IsFermi = "<<isFermi<<endl;
+    cout<<"Target PID = "<<targetPID<<endl;
     
     cout<<"**************************************************"<<endl;
     cout<<"*******"<<" RandomSeedActuallyUsed: "<<seed<<" *******"<<endl;
@@ -116,7 +120,10 @@ int main(int argc, char** argv) {
     
     const double PI = 3.14159265358979312;
     const double radian = 57.2957795130823229;
-    const double Mp = 0.9383;
+    const double M_p = 0.9383;
+    const double M_n = 0.939565;
+    double Mp=M_p;
+    if(targetPID==2112){Mp=M_n;}
     const double Me = 0.00051;
     //  const double Minv_min = sqrt(Mp*Mp + 2*Mp*Eg_min ) - Mp;
     
@@ -137,6 +144,7 @@ int main(int argc, char** argv) {
 
     TTCSKine tcs_kin1(Mp, Eb);
     TTCSCrs crs_lmlp;
+    crs_lmlp.Set_targetPID(targetPID);
 
     TLorentzVector target(0., 0., 0., Mp);
     TLorentzVector Lcm;
@@ -195,7 +203,7 @@ int main(int argc, char** argv) {
 
         double psf_Eg = Eg_max - Eg_min;
         Eg = rand.Uniform(Eg_min, Eg_min + psf_Eg);
-        flux_factor = N_EPA(Eb, Eg, q2_cut) + N_Brem(Eg, Eb);
+        flux_factor = N_EPA(Eb, Eg, q2_cut, targetPID) + N_Brem(Eg, Eb);
         s = Mp * Mp + 2 * Eg*(EFermi - p_prot_Fermi*cosThFermi );;
         double t_min = T_min(0., Mp*Mp, MinvMin2, Mp*Mp, s);
         double t_max = T_max(0., Mp*Mp, MinvMin2, Mp*Mp, s);
@@ -266,8 +274,8 @@ int main(int argc, char** argv) {
             eta = Q2 / (2 * (s - Mp * Mp) - Q2);
 
             if (Q2 < 9. && -t < 0.8 && eta < 0.8) {
-                crs_INT = crs_lmlp.Eval_INT(s, Q2, t, -1., tcs_kin1.GetPhi_cm(), tcs_kin1.GetTheta_cm(), 2.); //the last argumen "1" is the sc_D
-                //crs_INT = crs_lmlp.Eval_INT( tcs_kin1.GetPhi_cm(), tcs_kin1.GetTheta_cm(), 1.); //the last argumen "1" is the sc_D
+                crs_INT = crs_lmlp.Eval_INT(s, Q2, t, -1., tcs_kin1.GetPhi_cm(), tcs_kin1.GetTheta_cm(), 2.); //the last argument "1" is the sc_D
+                //crs_INT = crs_lmlp.Eval_INT( tcs_kin1.GetPhi_cm(), tcs_kin1.GetTheta_cm(), 1.,targetPID); //the last argument "1" is the sc_D
             } else {
                 crs_INT = 0;
             }
@@ -299,7 +307,7 @@ int main(int argc, char** argv) {
                     << pz_ep << setw(15) << L_ep.E() << setw(5) << 0 << setw(5) << 0 << setw(5) << 0 << setw(15) << vz << endl;
 
             //====== proton ======
-            out_dat << 3 << setw(5) << +1 << setw(5) << 1 << setw(7) << 2212 << setw(5) << 0 << setw(5) << 0 << setw(15) << px_prot << setw(15) << py_prot << setw(15)
+            out_dat << 3 << setw(5) << +1 << setw(5) << 1 << setw(7) << targetPID << setw(5) << 0 << setw(5) << 0 << setw(15) << px_prot << setw(15) << py_prot << setw(15)
                     << pz_prot << setw(15) << L_prot.E() << setw(5) << 0 << setw(5) << 0 << setw(5) << 0 << setw(15) << vz << endl;
 
         } else {

--- a/include/KinFunctions.h
+++ b/include/KinFunctions.h
@@ -16,6 +16,8 @@ namespace KinFuncs {
     double Q2_min(double s, double Eb, double M);
     double N_EPA(double, double, double );
     double N_Brem(double Eg, double Eb, double d = 5., double X0 = 929.); // 5 default target length used in RG-A, and 929 is the Liquid Hydrogen Rad length
+
+    double Fermi_Distribution(double *xx, double *par ); // Fermi momentum distributions, taken from Derek's repository https://github.com/dglazier/elSpectro/blob/f81ddbee096cbd586ba5f4ac1b9a36fd9fd7b19a/core/QuasiFreeNucleon.h#L26C97-L26C97
 }
 
 

--- a/include/KinFunctions.h
+++ b/include/KinFunctions.h
@@ -14,7 +14,7 @@ namespace KinFuncs {
     double T_min(double, double, double, double, double);
     double T_max(double, double, double, double, double);
     double Q2_min(double s, double Eb, double M);
-    double N_EPA(double, double, double );
+    double N_EPA(double, double, double, int);
     double N_Brem(double Eg, double Eb, double d = 5., double X0 = 929.); // 5 default target length used in RG-A, and 929 is the Liquid Hydrogen Rad length
 
     double Fermi_Distribution(double *xx, double *par ); // Fermi momentum distributions, taken from Derek's repository https://github.com/dglazier/elSpectro/blob/f81ddbee096cbd586ba5f4ac1b9a36fd9fd7b19a/core/QuasiFreeNucleon.h#L26C97-L26C97

--- a/include/TTCSCrs.h
+++ b/include/TTCSCrs.h
@@ -31,6 +31,9 @@ public:
     void Draw_INT(const char* option, double sc_D = 1.);
     TH2D *Get_BH_Crs_Histogream_ThPhi(const char *name, int iweight = 1);
     TH2D *Get_INT_Crs_Histogream_ThPhi(const char *name, int iweight = 1);
+    void Set_targetPID(int tPID){
+      targetPID=tPID;
+    }
 
 
     virtual ~TTCSCrs();
@@ -38,10 +41,12 @@ private:
     double is, iQ2, it;
     double iweight;
     double isc_D;
+    int targetPID=2212;
     GPDs *gp;
     static constexpr double radian = 57.2957795130823229;
     static constexpr double m_e = 0.00051;
     static constexpr double M_p = 0.938272;
+    static constexpr double M_n = 0.939565;
     static constexpr double alpha_em = 1. / 137.;
     static constexpr double PI = 3.14159265358979312;
     static constexpr double ammp = 2.793;

--- a/include/TTCSCrs.h
+++ b/include/TTCSCrs.h
@@ -15,7 +15,7 @@
 class TTCSCrs {
 public:
     TTCSCrs();
-    TTCSCrs(double, double, double); // s(GeV)^2, Q2(GeV)^2, t(GeV)^2
+    TTCSCrs(double, double, double, double); // s(GeV)^2, Q2(GeV)^2, t(GeV)^2
     /*TTCSCrs(const TTCSCrs& orig);*/
 
     double Eval_BH(double, double) const; // phi and theta in radians

--- a/src/KinFunctions.cc
+++ b/src/KinFunctions.cc
@@ -32,7 +32,7 @@ double KinFuncs::Q2_min( double s, double Eb, double M )
   return Q2min;
 }
 
-double KinFuncs::N_EPA(double Eb, double Eg, double Q2_max)
+double KinFuncs::N_EPA(double Eb, double Eg, double Q2_max, int targetPID)
 {
   const double alpha = 1./137.;
   const double PI = 3.14159265358979312;
@@ -40,6 +40,7 @@ double KinFuncs::N_EPA(double Eb, double Eg, double Q2_max)
   double x = Eg/Eb;
   double me = 0.00051;
   double Mp = 0.9383;
+  if(targetPID==2112){Mp=0.939565;}
   double Q2_min = me*me*x*x/(1 - x);
   return (1/Eb)*alpha/(PI*x)*( (1 - x + x*x/2)*log(Q2_max/Q2_min) - (1 - x));
 }

--- a/src/KinFunctions.cc
+++ b/src/KinFunctions.cc
@@ -49,3 +49,8 @@ double KinFuncs::N_Brem(double Eg, double Eb, double d, double X0)
   // The factor 0.5 is because when one integrates over (l - x)*dx, then you get l^2/2
   return (0.5*d/X0)*(1/Eg)*((4./3.) - (4./3.)*(Eg/Eb) + Eg*Eg/(Eb*Eb));
 }
+
+double KinFuncs::Fermi_Distribution(double *xx, double *par) {
+  double x = xx[0];
+  return (x * (0.26 * 0.26 - 0.0456 * 0.0456) / (x * x + 0.0456 * 0.0456) / (x * x + 0.26 * 0.26))*(x * (0.26 * 0.26 - 0.0456 * 0.0456) / (x * x + 0.0456 * 0.0456) / (x * x + 0.26 * 0.26));
+}

--- a/src/KinFunctions.cc
+++ b/src/KinFunctions.cc
@@ -51,7 +51,12 @@ double KinFuncs::N_Brem(double Eg, double Eb, double d, double X0)
   return (0.5*d/X0)*(1/Eg)*((4./3.) - (4./3.)*(Eg/Eb) + Eg*Eg/(Eb*Eb));
 }
 
-double KinFuncs::Fermi_Distribution(double *xx, double *par) {
+/*double KinFuncs::Fermi_Distribution(double *xx, double *par) {
   double x = xx[0];
   return (x * (0.26 * 0.26 - 0.0456 * 0.0456) / (x * x + 0.0456 * 0.0456) / (x * x + 0.26 * 0.26))*(x * (0.26 * 0.26 - 0.0456 * 0.0456) / (x * x + 0.0456 * 0.0456) / (x * x + 0.26 * 0.26));
+}*/
+
+double KinFuncs::Fermi_Distribution(double *xx, double *par) {
+  double x = xx[0];
+  return 35*((x * ((-0.114) * (-0.114) - 0.1108 * 0.1108) / (x * x + 0.1108 * 0.1108) / (x * x + (-0.114) * (-0.114)))*(x * ((-0.114) * (-0.114) - 0.1108 * 0.1108) / (x * x + 0.1108 * 0.1108) / (x * x + (-0.114) * (-0.114))));
 }

--- a/src/TTCSCrs.cc
+++ b/src/TTCSCrs.cc
@@ -27,6 +27,9 @@ TTCSCrs::TTCSCrs() {
 
 TTCSCrs::TTCSCrs(double a_s, double a_Q2, double a_t) {
 
+    double M_nuc = M_p;
+    if(targetPID==2112){M_nuc=M_n;}
+
     TString dat="CFFs_DD_Feb2012.dat";
     if (gSystem->AccessPathName(dat))
         dat=gSystem->Getenv("TCSGEN_DIR")+TString("/")+dat;
@@ -37,7 +40,7 @@ TTCSCrs::TTCSCrs(double a_s, double a_Q2, double a_t) {
     f_BH->SetParameters(is, iQ2, it);
 
     f_INT = new TF2("f_INT", INT_crs_section, 0., 360., 0., 180., 12);
-    double eta = iQ2 / (2 * (is - M_p * M_p) - iQ2);
+    double eta = iQ2 / (2 * (is - M_nuc * M_nuc) - iQ2);
     gp = new GPDs(dat, 17, 17, 9, iQ2, it, eta);
     gp->Set_q2_t_eta(iQ2, it, eta);
 }
@@ -55,33 +58,41 @@ double TTCSCrs::BH_crs_section(double *x, double *par) {
     double s = par[0];
     double Q2 = par[1];
     double t = par[2];
+    double tPID = par[4]; //par[3] is weight
+
+    double M_nuc = M_p;
+    if(tPID==2112){M_nuc=M_n;}
 
     //cout<<" s Q2 t phi, theta ="<<s<<"  "<<Q2<<"  "<<t<<"  "<<phi<<"  "<<theta<<endl;
 
     double weight;
 
     double beta = sqrt(1 - (4 * m_e * m_e) / Q2);
-    double r = sqrt((s - Q2 - M_p * M_p)*(s - Q2 - M_p * M_p) - 4 * Q2 * M_p * M_p);
-    double tau = Q2 / (s - M_p * M_p);
-    double cos_TH_Cm = (2 * s * (t - 2 * M_p * M_p) + (s + M_p * M_p)*(s + M_p * M_p - Q2)) / sqrt(Lambda(s, M_p*M_p, 0) * Lambda(s, M_p*M_p, Q2));
+    double r = sqrt((s - Q2 - M_nuc * M_nuc)*(s - Q2 - M_nuc * M_nuc) - 4 * Q2 * M_nuc * M_nuc);
+    double tau = Q2 / (s - M_nuc * M_nuc);
+    double cos_TH_Cm = (2 * s * (t - 2 * M_nuc * M_nuc) + (s + M_nuc * M_nuc)*(s + M_nuc * M_nuc - Q2)) / sqrt(Lambda(s, M_nuc*M_nuc, 0) * Lambda(s, M_nuc*M_nuc, Q2));
     double sin_TH_Cm = sqrt(1 - cos_TH_Cm * cos_TH_Cm);
     double Delta_Perp = sin_TH_Cm * r / (2 * sqrt(s));
     //iDelta_Perp = Delta_Perp;
-    //double Delta_Perp = sqrt((-t)*(1 - tau) - tau*tau*M_p*M_p );
+    //double Delta_Perp = sqrt((-t)*(1 - tau) - tau*tau*M_nuc*M_nuc );
     double a = beta * r * cos(theta);
 
-    double b = beta * ((Q2 * (s - M_p * M_p - Q2) + t * (s - M_p * M_p + Q2)) / r) * cos(theta) -
-            beta * ((2 * (s - M_p * M_p) * sqrt(Q2) * Delta_Perp) / r) * sin(theta) * cos(phi);
+    double b = beta * ((Q2 * (s - M_nuc * M_nuc - Q2) + t * (s - M_nuc * M_nuc + Q2)) / r) * cos(theta) -
+            beta * ((2 * (s - M_nuc * M_nuc) * sqrt(Q2) * Delta_Perp) / r) * sin(theta) * cos(phi);
 
     double L_BH = ((Q2 - t)*(Q2 - t) - b * b) / 4.;
     double L0_BH = Q2 * Q2 * sin(theta) * sin(theta) / 4.;
-    double A_BH = (s - M_p * M_p)*(s - M_p * M_p) * Delta_Perp * Delta_Perp - t * a * (a + b) - M_p * M_p * b * b - t * (4 * M_p * M_p - t) * Q2 +
-            (m_e * m_e / L_BH)*(TMath::Power((Q2 - t)*(a + b) - (s - M_p * M_p) * b, 2) + t * (4 * M_p * M_p - t)*(Q2 - t)*(Q2 - t));
+    double A_BH = (s - M_nuc * M_nuc)*(s - M_nuc * M_nuc) * Delta_Perp * Delta_Perp - t * a * (a + b) - M_nuc * M_nuc * b * b - t * (4 * M_nuc * M_nuc - t) * Q2 +
+            (m_e * m_e / L_BH)*(TMath::Power((Q2 - t)*(a + b) - (s - M_nuc * M_nuc) * b, 2) + t * (4 * M_nuc * M_nuc - t)*(Q2 - t)*(Q2 - t));
 
     double B_BH = (Q2 + t)*(Q2 + t) + b * b + 8 * m_e * m_e * Q2 - 4 * m_e * m_e * (t + 2 * m_e * m_e)*(Q2 - t)*(Q2 - t) / L_BH;
 
-    double F1p = (1. / ((1 - t / 0.71)*(1 - t / 0.71)))*(1 / (1 - t / (4. * M_p * M_p)))*(1 - 2.79 * t / (4 * M_p * M_p));
-    double F2p = (1. / ((1 - t / 0.71)*(1 - t / 0.71)))*(1 / (1 - t / (4. * M_p * M_p)))*(ammp - 1);
+    double F1p = (1. / ((1 - t / 0.71)*(1 - t / 0.71)))*(1 / (1 - t / (4. * M_nuc * M_nuc)))*(1 - 2.79 * t / (4 * M_nuc * M_nuc));
+    double F2p = (1. / ((1 - t / 0.71)*(1 - t / 0.71)))*(1 / (1 - t / (4. * M_nuc * M_nuc)))*(ammp - 1);
+    if(tPID==2112){
+        F1p = (1./((1 - t/0.71)*(1 - t/0.71)))*(1/(1 - t/(4.*M_nuc*M_nuc) ))*(-ammn*t/(4*M_nuc*M_nuc));
+        F2p = (1./((1 - t/0.71)*(1 - t/0.71)))*(1/(1 - t/(4.*M_nuc*M_nuc) ))*ammn;
+    }
 
     if (par[3] == 1) {
         weight = L_BH / L0_BH;
@@ -90,8 +101,8 @@ double TTCSCrs::BH_crs_section(double *x, double *par) {
     }
 
     /*With (sin(theta)) it returns dsigma/dTheta, without it is dSigma/dCos(Theta) */ 
-    double crs = /*(sin(theta))* */ 1./(2*PI)*weight *(TMath::Power(alpha_em, 3) / (4 * PI * (s - M_p * M_p)*(s - M_p * M_p)))*(beta / (-t * L_BH))*
-            ((A_BH / (-t))*(F1p * F1p - (t / (4 * M_p * M_p)) * F2p * F2p) + (F1p + F2p)*(F1p + F2p) * B_BH / 2)*
+    double crs = /*(sin(theta))* */ 1./(2*PI)*weight *(TMath::Power(alpha_em, 3) / (4 * PI * (s - M_nuc * M_nuc)*(s - M_nuc * M_nuc)))*(beta / (-t * L_BH))*
+            ((A_BH / (-t))*(F1p * F1p - (t / (4 * M_nuc * M_nuc)) * F2p * F2p) + (F1p + F2p)*(F1p + F2p) * B_BH / 2)*
             0.389379 * 1e9;
 
     return crs;
@@ -117,32 +128,39 @@ double TTCSCrs::INT_crs_section(double *x, double *par) {
     double ImHtild = par[9];
     double ReHtild = par[10];
     double Dterm = par[11];
+    double tPID= par[12];
+
+    double M_nuc = M_p;
+    if(tPID==2112){M_nuc=M_n;}
 
     double sigma = 1.;
 
     double beta = sqrt(1 - (4 * m_e * m_e) / Q2);
-    double r = sqrt((s - Q2 - M_p * M_p)*(s - Q2 - M_p * M_p) - 4 * Q2 * M_p * M_p);
-    double tau = Q2 / (s - M_p * M_p);
+    double r = sqrt((s - Q2 - M_nuc * M_nuc)*(s - Q2 - M_nuc * M_nuc) - 4 * Q2 * M_nuc * M_nuc);
+    double tau = Q2 / (s - M_nuc * M_nuc);
     double eta = tau / (2 - tau);
-    double cos_TH_Cm = (2 * s * (t - 2 * M_p * M_p) + (s + M_p * M_p)*(s + M_p * M_p - Q2)) / sqrt(Lambda(s, M_p*M_p, 0) * Lambda(s, M_p*M_p, Q2));
+    double cos_TH_Cm = (2 * s * (t - 2 * M_nuc * M_nuc) + (s + M_nuc * M_nuc)*(s + M_nuc * M_nuc - Q2)) / sqrt(Lambda(s, M_nuc*M_nuc, 0) * Lambda(s, M_nuc*M_nuc, Q2));
     double sin_TH_Cm = sqrt(1 - cos_TH_Cm * cos_TH_Cm);
     double Delta_Perp = sin_TH_Cm * r / (2 * sqrt(s));
-    //double Delta_Perp = sqrt((-t)*(1 - tau) - tau*tau*M_p*M_p );
+    //double Delta_Perp = sqrt((-t)*(1 - tau) - tau*tau*M_nuc*M_nuc );
     double a = beta * r * cos(theta);
-    double b = sigma * beta * sqrt((Q2 - t)*(Q2 - t) - TMath::Power((2 * (s - M_p * M_p) * sqrt(Q2) * Delta_Perp) / r, 2)) * cos(theta) -
-            beta * ((2 * (s - M_p * M_p) * sqrt(Q2) * Delta_Perp) / r) * sin(theta) * cos(phi);
+    double b = sigma * beta * sqrt((Q2 - t)*(Q2 - t) - TMath::Power((2 * (s - M_nuc * M_nuc) * sqrt(Q2) * Delta_Perp) / r, 2)) * cos(theta) -
+            beta * ((2 * (s - M_nuc * M_nuc) * sqrt(Q2) * Delta_Perp) / r) * sin(theta) * cos(phi);
     double L_BH = ((Q2 - t)*(Q2 - t) - b * b) / 4.;
     double L0_BH = Q2 * Q2 * sin(theta) * sin(theta) / 4.;
 
-    double F1p = (1. / ((1 - t / 0.71)*(1 - t / 0.71)))*(1 / (1 - t / (4. * M_p * M_p)))*(1 - 2.79 * t / (4 * M_p * M_p));
-    double F2p = (1. / ((1 - t / 0.71)*(1 - t / 0.71)))*(1 / (1 - t / (4. * M_p * M_p)))*(ammp - 1);
-    //double F1n = (1./((1 - t/0.71)*(1 - t/0.71)))*(1/(1 - t/(4.*M_p*M_p) ))*(-ammn*t/(4*M_p*M_p));
-    //double F2n = (1./((1 - t/0.71)*(1 - t/0.71)))*(1/(1 - t/(4.*M_p*M_p) ))*ammn;
+    double F1p = (1. / ((1 - t / 0.71)*(1 - t / 0.71)))*(1 / (1 - t / (4. * M_nuc * M_nuc)))*(1 - 2.79 * t / (4 * M_nuc * M_nuc));
+    double F2p = (1. / ((1 - t / 0.71)*(1 - t / 0.71)))*(1 / (1 - t / (4. * M_nuc * M_nuc)))*(ammp - 1);
+    if(tPID==2112){
+        F1p = (1./((1 - t/0.71)*(1 - t/0.71)))*(1/(1 - t/(4.*M_nuc*M_nuc) ))*(-ammn*t/(4*M_nuc*M_nuc));
+        F2p = (1./((1 - t/0.71)*(1 - t/0.71)))*(1/(1 - t/(4.*M_nuc*M_nuc) ))*ammn;
+    }
+    
 
-    double t_min = -4 * eta * eta * M_p * M_p / (1 - eta * eta);
+    double t_min = -4 * eta * eta * M_nuc * M_nuc / (1 - eta * eta);
 
-    double M2_int = 2 * sqrt(t_min - t) / M_p * (1 - eta) / (1 + eta)*(F1p * (ReH + sc_D * Dterm) - eta * (F1p + F2p) * ReHtild -
-            (t / (4 * M_p * M_p)) * F2p * (ReE - sc_D * Dterm));
+    double M2_int = 2 * sqrt(t_min - t) / M_nuc * (1 - eta) / (1 + eta)*(F1p * (ReH + sc_D * Dterm) - eta * (F1p + F2p) * ReHtild -
+            (t / (4 * M_nuc * M_nuc)) * F2p * (ReE - sc_D * Dterm));
 
     if (par[4] == 1) {
         weight = L_BH / L0_BH;
@@ -150,8 +168,8 @@ double TTCSCrs::INT_crs_section(double *x, double *par) {
         weight = 1;
     }
     //cout<<"M2_int = "<<M2_int<<endl;
-    double sigma_int = 1./(2*PI) * weight * (-TMath::Power(alpha_em, 3)) / (4 * PI * s * s)*(-1 / t)*(M_p / sqrt(Q2))*(1 / (tau * sqrt(1 - tau))) * L0_BH / L_BH *
-            //double sigma_int = weight*(-TMath::Power(alpha_em, 3))/(4*PI*s*s)*(-1/t)*(M_p/sqrt(Q2))*(1/(tau*sqrt(1 - tau)))*L0_BH/L_BH*
+    double sigma_int = 1./(2*PI) * weight * (-TMath::Power(alpha_em, 3)) / (4 * PI * s * s)*(-1 / t)*(M_nuc / sqrt(Q2))*(1 / (tau * sqrt(1 - tau))) * L0_BH / L_BH *
+            //double sigma_int = weight*(-TMath::Power(alpha_em, 3))/(4*PI*s*s)*(-1/t)*(M_nuc/sqrt(Q2))*(1/(tau*sqrt(1 - tau)))*L0_BH/L_BH*
             cos(phi)*(1 + cos(theta) * cos(theta)) / sin(theta) * M2_int *
             0.389379 * 1e9;
 
@@ -161,21 +179,24 @@ double TTCSCrs::INT_crs_section(double *x, double *par) {
 }
 
 double TTCSCrs::Eval_BH(double a_phi, double a_th) const {
-    f_BH->SetParameters(is, iQ2, it, iweight);
+    f_BH->SetParameters(is, iQ2, it, iweight,targetPID);
 
     return f_BH->Eval(a_phi, a_th);
 }
 
 double TTCSCrs::Eval_BH(double a_s, double a_Q2, double a_t, double a_weight, double a_phi, double a_th) const {
 
-    f_BH->SetParameters(a_s, a_Q2, a_t, a_weight);
+    f_BH->SetParameters(a_s, a_Q2, a_t, a_weight,targetPID);
     return f_BH->Eval(a_phi, a_th);
 
 }
 
 double TTCSCrs::Eval_INT(double a_phi, double a_th, double a_sc_D) const {
 
-    double eta = iQ2 / (2 * (is - M_p * M_p) - iQ2);
+    double M_nuc = M_p;
+    if(targetPID==2112){M_nuc=M_n;}
+
+    double eta = iQ2 / (2 * (is - M_nuc * M_nuc) - iQ2);
     gp->Set_q2_t_eta(iQ2, it, eta);
 
     double ImH = gp->GetImH();
@@ -188,11 +209,15 @@ double TTCSCrs::Eval_INT(double a_phi, double a_th, double a_sc_D) const {
 
     f_INT->SetParameters(is, iQ2, it, a_sc_D, iweight, ImH, ReH, ImE, ReE, ImHtild, ReHtild);
     f_INT->SetParameter(11, Dterm);
+    f_INT->SetParameter(12, targetPID);
     return f_INT->Eval(a_phi, a_th);
 }
 
 double TTCSCrs::Eval_INT(double a_s, double a_Q2, double a_t, double a_weight, double a_phi, double a_th, double a_sc_D) const {
-    double eta = a_Q2 / (2 * (a_s - M_p * M_p) - a_Q2);
+    double M_nuc = M_p;
+    if(targetPID==2112){M_nuc=M_n;}
+
+    double eta = a_Q2 / (2 * (a_s - M_nuc * M_nuc) - a_Q2);
     gp->Set_q2_t_eta(a_Q2, a_t, eta);
 
     double ImH = gp->GetImH();
@@ -206,6 +231,7 @@ double TTCSCrs::Eval_INT(double a_s, double a_Q2, double a_t, double a_weight, d
 
     f_INT->SetParameters(a_s, a_Q2, a_t, a_sc_D, a_weight, ImH, ReH, ImE, ReE, ImHtild, ReHtild);
     f_INT->SetParameter(11, Dterm);
+    f_INT->SetParameter(12, targetPID);
     return f_INT->Eval(a_phi, a_th);
 }
 
@@ -217,7 +243,7 @@ void TTCSCrs::Set_SQ2t(double a_s, double a_Q2, double a_t) {
 
 double TTCSCrs::Integral_BH_phi_th(double a_phi_min, double a_phi_max, double a_th_min, double a_th_max) {
 
-    f_BH->SetParameters(is, iQ2, it, iweight);
+    f_BH->SetParameters(is, iQ2, it, iweight,targetPID);
     return f_BH->Integral(a_phi_min, a_phi_max, a_th_min, a_th_max);
 }
 
@@ -232,12 +258,16 @@ void TTCSCrs::Set_sc_D(double a_sc_D) {
 void TTCSCrs::Draw_BH(const char* option) {
     f_BH->SetNpx(900);
     f_BH->SetNpy(900);
-    f_BH->SetParameters(is, iQ2, it, iweight);
+    f_BH->SetParameters(is, iQ2, it, iweight,targetPID);
     f_BH->Draw(option);
 }
 
 void TTCSCrs::Draw_INT(const char* option, double a_sc_D) {
-    double eta = iQ2 / (2 * (is - M_p * M_p) - iQ2);
+
+    double M_nuc = M_p;
+    if(targetPID==2112){M_nuc=M_n;}
+
+    double eta = iQ2 / (2 * (is - M_nuc * M_nuc) - iQ2);
     gp->Set_q2_t_eta(iQ2, it, eta);
 
     double ImH = gp->GetImH();
@@ -250,6 +280,7 @@ void TTCSCrs::Draw_INT(const char* option, double a_sc_D) {
 
     f_INT->SetParameters(is, iQ2, it, a_sc_D, iweight, ImH, ReH, ImE, ReE, ImHtild, ReHtild);
     f_INT->SetParameter(11, Dterm);
+    f_INT->SetParameter(12, targetPID);
     f_INT->SetNpx(500);
     f_INT->SetNpy(500);
     f_INT->Draw(option);
@@ -257,7 +288,7 @@ void TTCSCrs::Draw_INT(const char* option, double a_sc_D) {
 
 TH2D *TTCSCrs::Get_BH_Crs_Histogream_ThPhi(const char *name, int weight) {
     TCanvas *ctmp = new TCanvas();
-    f_BH->SetParameters(is, iQ2, it, weight);
+    f_BH->SetParameters(is, iQ2, it, weight,targetPID);
     f_BH->SetNpx(500);
     f_BH->SetNpy(500);
     f_BH->Draw("colz");
@@ -268,8 +299,12 @@ TH2D *TTCSCrs::Get_BH_Crs_Histogream_ThPhi(const char *name, int weight) {
 }
 
 TH2D *TTCSCrs::Get_INT_Crs_Histogream_ThPhi(const char *name, int weight) {
+
+    double M_nuc = M_p;
+    if(targetPID==2112){M_nuc=M_n;}
+
     TCanvas *ctmp = new TCanvas(); // Without this I was getting crazy results in utility programs :-)
-    double eta = iQ2 / (2 * (is - M_p * M_p) - iQ2);
+    double eta = iQ2 / (2 * (is - M_nuc * M_nuc) - iQ2);
     gp->Set_q2_t_eta(iQ2, it, eta);
 
     double ImH = gp->GetImH();
@@ -282,6 +317,7 @@ TH2D *TTCSCrs::Get_INT_Crs_Histogream_ThPhi(const char *name, int weight) {
 
     f_INT->SetParameters(is, iQ2, it, isc_D, weight, ImH, ReH, ImE, ReE, ImHtild, ReHtild);
     f_INT->SetParameter(11, Dterm);
+    f_INT->SetParameter(12, targetPID);
     f_INT->SetNpx(500);
     f_INT->SetNpy(500);
     f_INT->Draw("colz");

--- a/src/TTCSCrs.cc
+++ b/src/TTCSCrs.cc
@@ -20,12 +20,14 @@ TTCSCrs::TTCSCrs() {
     if (gSystem->AccessPathName(dat))
         dat=gSystem->Getenv("TCSGEN_DIR")+TString("/")+dat;
     
-    f_BH = new TF2("f_BH", BH_crs_section, 0, 360, 0, 180, 4);
-    f_INT = new TF2("f_INT", INT_crs_section, 0., 360., 0., 180., 12);
+    f_BH = new TF2("f_BH", BH_crs_section, 0, 360, 0, 180, 5);
+    f_INT = new TF2("f_INT", INT_crs_section, 0., 360., 0., 180., 13);
     gp = new GPDs(dat, 17, 17, 9, 1.49, -0.20, 0.072);
 }
 
-TTCSCrs::TTCSCrs(double a_s, double a_Q2, double a_t) {
+TTCSCrs::TTCSCrs(double a_s, double a_Q2, double a_t, double tpid) {
+
+    targetPID=tpid;
 
     double M_nuc = M_p;
     if(targetPID==2112){M_nuc=M_n;}
@@ -36,8 +38,8 @@ TTCSCrs::TTCSCrs(double a_s, double a_Q2, double a_t) {
 
     Set_SQ2t(a_s, a_Q2, a_t);
     iweight = -1;
-    f_BH = new TF2("f_BH", BH_crs_section, 0, 360, 0, 180, 4);
-    f_BH->SetParameters(is, iQ2, it);
+    f_BH = new TF2("f_BH", BH_crs_section, 0, 360, 0, 180, 5);
+    f_BH->SetParameters(is, iQ2, it,targetPID);
 
     f_INT = new TF2("f_INT", INT_crs_section, 0., 360., 0., 180., 12);
     double eta = iQ2 / (2 * (is - M_nuc * M_nuc) - iQ2);
@@ -180,12 +182,10 @@ double TTCSCrs::INT_crs_section(double *x, double *par) {
 
 double TTCSCrs::Eval_BH(double a_phi, double a_th) const {
     f_BH->SetParameters(is, iQ2, it, iweight,targetPID);
-
     return f_BH->Eval(a_phi, a_th);
 }
 
 double TTCSCrs::Eval_BH(double a_s, double a_Q2, double a_t, double a_weight, double a_phi, double a_th) const {
-
     f_BH->SetParameters(a_s, a_Q2, a_t, a_weight,targetPID);
     return f_BH->Eval(a_phi, a_th);
 


### PR DESCRIPTION
Added options for Fermi motion of target nucleons and using a neutron as the target nucleon. Most changes should be straightforward to understand. Two things to note:
- There was already the neutron F1 and F2 form factors commented out in the code, should check these are still correct (I think so)
- Some variable names originally named for the proton (eg Mp) are unchanged. This might cause confusion and so I tried to change this as much as possible (eg M_nuc) but I might've missed some.